### PR TITLE
docs: updated url link to yandex translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sandbox permissions:
 
 #### Install parameters
 
-Generate a [Yandex API Key](https://translate.yandex.com/developers/keys) and pass it to the extension:
+Generate a [Yandex API Key](https://yandex.cloud/en/services/translate) and pass it to the extension:
 
 
 ```json


### PR DESCRIPTION
Updated the link to Yandex as their  v1.5 translation API is closed and they have migrate to [the Yandex.Cloud transfer API](https://cloud.yandex.ru/services/translate)